### PR TITLE
Free malloc-ed 'async_calculate_data' in the completion function.

### DIFF
--- a/async_pi_estimate/napi/async.cc
+++ b/async_pi_estimate/napi/async.cc
@@ -38,6 +38,8 @@ void doneCalculation(napi_env env, napi_status status, void* param) {
   status = napi_create_double(env, data->estimate, &argv[1]);
   assert(status == napi_ok);
 
+  free(data);
+
   napi_value result;
   status = napi_call_function(env, global, callback, 2, argv, &result);
   assert(status == napi_ok);

--- a/async_pi_estimate/napi/async.cc
+++ b/async_pi_estimate/napi/async.cc
@@ -38,6 +38,8 @@ void doneCalculation(napi_env env, napi_status status, void* param) {
   status = napi_create_double(env, data->estimate, &argv[1]);
   assert(status == napi_ok);
 
+  status = napi_delete_async_work(env, data->_request);
+  assert(status == napi_ok);
   free(data);
 
   napi_value result;


### PR DESCRIPTION
The data for the asynchronous worker is allocated with "malloc" in CalculateAsync(..), but it is never freed.

To avoid a memory leak, I call "free" in the completion function.

Thanks for providing a correct example of asynchronous working threads under N-API.